### PR TITLE
Improve risk management

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+# Bybit Spot <-> Perp Arbitrage Bot
+
+This project implements an automated arbitrage trading system for Bybit. It streams orderbook data via WebSockets, applies reinforcement learning to estimate profitable edges and executes trades with a REST API client.
+
+## Requirements
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Edit `.env` with your API keys and run:
+
+```bash
+python run_trading_system.py
+```
+
+Prometheus metrics will be served on `PROM_HOST:PROM_PORT`.
+
+Trained RL policies are saved in `policies/` and automatically reloaded on
+startup. WebSocket reconnects are counted by a Prometheus metric
+`ws_reconnect_total`.
+
+Set `MAX_DRAWDOWN_USD` to stop the bot if cumulative losses exceed this
+threshold. Alerts will be sent via email or Telegram if configured.
+
+### Offline Backtesting
+
+Historical quotes in CSV format can be used to test strategies without
+connecting to the exchange. Each row should contain `symbol`, `bid` and `ask`
+columns.
+
+```bash
+python backtester.py data.csv
+```
+

--- a/backtester.py
+++ b/backtester.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+import argparse, csv
+from decimal import Decimal
+from pathlib import Path
+from typing import Iterable
+
+import config
+from strategy_multi import ArbitrageStrategyMulti
+from api_client import APIClient
+
+class CsvData:
+    """Iterate over historical price data from CSV."""
+
+    def __init__(self, path: Path):
+        self.path = path
+
+    def __iter__(self) -> Iterable[tuple[str, Decimal, Decimal]]:
+        with self.path.open() as f:
+            reader = csv.DictReader(f)
+            for row in reader:
+                yield row["symbol"], Decimal(row["bid"]), Decimal(row["ask"])
+
+async def backtest(data: CsvData):
+    async with APIClient() as client:
+        strat = ArbitrageStrategyMulti(client)
+        pnl = {s: Decimal() for s in config.TRADE_PAIRS}
+        for sym, bid, ask in data:
+            client.ws.best[sym] = (bid, ask)
+            action, edge = await strat.analyze(sym)
+            if action == "buy_spot":
+                pnl[sym] -= ask
+            elif action == "sell_spot":
+                pnl[sym] += bid
+        for sym, p in pnl.items():
+            print(sym, "PNL", p)
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser(description="Offline backtesting")
+    ap.add_argument("csv", type=Path, help="CSV with symbol,bid,ask")
+    args = ap.parse_args()
+    import asyncio
+    asyncio.run(backtest(CsvData(args.csv)))
+

--- a/config.py
+++ b/config.py
@@ -39,16 +39,33 @@ FUTURES_FEE_MAKER      = Decimal(os.getenv("FUTURES_FEE_MAKER_RATE", "0.00020"))
 FUNDING_INTERVAL_HOURS = int(os.getenv("FUNDING_INTERVAL_HOURS",  "8"))
 MIN_FUNDING_THRESHOLD  = Decimal(os.getenv("MIN_FUNDING_THRESHOLD", "0.0001"))
 
+# максимальный допустимый убыток в долларах, после которого бот остановится
+MAX_DRAWDOWN_USD = Decimal(os.getenv("MAX_DRAWDOWN_USD", "100"))
+
 USE_RL_MODEL  = os.getenv("USE_RL_MODEL", "true").lower() in ("true", "1", "yes")
 RL_MODEL_PATH = Path(os.getenv("RL_MODEL_PATH", "./policies/ppo_latest.zip"))
 RL_UPDATE_SEC = int(os.getenv("RL_UPDATE_SEC", "30"))
 RL_MIN_ROLLOUT= int(os.getenv("RL_MIN_ROLLOUT", "512"))
 RL_BUFFER_CAP = 2048
 
-PROM_HOST  = os.getenv("PROM_HOST", "0.0.0.0")
-PROM_PORT  = int(os.getenv("PROM_PORT", "9100"))
+PROM_HOST = os.getenv("PROM_HOST", "0.0.0.0")
+PROM_PORT = int(os.getenv("PROM_PORT", "9100"))
 
-LOG_LEVEL  = os.getenv("LOG_LEVEL", "INFO").upper()
-LOG_FILE   = LOG_DIR / "bot.log"
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOG_FILE  = LOG_DIR / "bot.log"
+
+EMAIL_ENABLED  = os.getenv("EMAIL_ENABLED", "0").lower() in ("1", "true", "yes")
+EMAIL_SENDER   = os.getenv("EMAIL_SENDER", "")
+EMAIL_PASSWORD = os.getenv("EMAIL_PASSWORD", "")
+ALERT_EMAILS   = os.getenv("ALERT_EMAILS", "")
+TG_BOT_TOKEN   = os.getenv("TG_BOT_TOKEN", "")
+TG_CHAT_ID     = os.getenv("TG_CHAT_ID", "")
+
+def get_model_path(sym: str) -> Path:
+    """Return RL model path for a trading pair."""
+    p = RL_MODEL_PATH
+    if "{sym}" in str(p):
+        return Path(str(p).format(sym=sym))
+    return p.with_name(f"{p.stem}_{sym}{p.suffix}")
 
 getcontext().prec = 18

--- a/logger.py
+++ b/logger.py
@@ -36,3 +36,4 @@ def setup_logger() -> logging.Logger:
     return logger
 
 setup_logger()
+

--- a/monitoring.py
+++ b/monitoring.py
@@ -16,6 +16,7 @@ CYCLE_LATENCY_MS = Gauge("cycle_latency_ms", "Loop latency ms",           ["sym"
 ORDERS_ACTIVE    = Gauge("orders_active",    "Active orders flag",        ["sym"])
 POSITION_SIZE    = Gauge("position_size",    "Position size",             ["sym"])
 ERROR_COUNTER    = Counter("error_total",    "Total errors",              ["type"])
+WS_RECONNECTS    = Counter("ws_reconnect_total", "WebSocket reconnects")
 
 async def metrics_handler(_: web.Request):
     return web.Response(body=generate_latest(), content_type=CONTENT_TYPE_LATEST)
@@ -35,3 +36,4 @@ async def heartbeat():
     while True:
         POSITION_SIZE.labels(sym="heartbeat").set(time.time())
         await asyncio.sleep(15)
+

--- a/rebalancer.py
+++ b/rebalancer.py
@@ -23,3 +23,4 @@ async def smart_rebalance(client: "APIClient", bot: "TradingBotMulti"):  # noqa:
                 logger.info("Rebalance %s %s %.6f", sym, side, qty)
         except Exception as exc:
             logger.warning("Rebalance err: %s", exc)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ unstructured==0.18.11
 jupyter==1.1.1
 ipykernel==6.30.0
 nbconvert==7.16.6
+

--- a/retry_utils.py
+++ b/retry_utils.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+import logging
+from typing import Awaitable, Callable, TypeVar
+import tenacity
+
+logger = logging.getLogger(__name__)
+_T = TypeVar("_T")
+
+async def retry_async(
+    func: Callable[[], Awaitable[_T]],
+    *, attempts: int = 4, wait: float = 0.5, backoff: float = 2.0
+) -> _T:
+    @tenacity.retry(
+        reraise=True,
+        stop=tenacity.stop_after_attempt(attempts),
+        wait=tenacity.wait_exponential(multiplier=wait, exp_base=backoff),
+        before_sleep=lambda rs: logger.warning(
+            "retry %s/%s: %s", rs.attempt_number, attempts, rs.outcome.exception()
+        ),
+    )
+    async def _wrapper() -> _T:
+        return await func()
+    return await _wrapper()

--- a/risk_manager.py
+++ b/risk_manager.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+import asyncio, logging, os, signal
+from decimal import Decimal
+from alert_utils import ALERTS
+import config
+
+logger = logging.getLogger(__name__)
+
+class RiskManager:
+    """Monitor PnL and stop trading if losses exceed configured limits."""
+    CHECK_INTERVAL = 30  # seconds
+
+    def __init__(self, bot: "TradingBotMulti") -> None:  # noqa: F821
+        self.bot = bot
+
+    async def watch(self) -> None:
+        while True:
+            await asyncio.sleep(self.CHECK_INTERVAL)
+            pnl = sum(self.bot.real.values())
+            if pnl <= -config.MAX_DRAWDOWN_USD:
+                ALERTS.error(
+                    f"Порог убытка {config.MAX_DRAWDOWN_USD}$ превышен ({pnl}$)"
+                )
+                logger.warning("Останавливаем бота из-за превышения убытков")
+                os.kill(os.getpid(), signal.SIGTERM)
+

--- a/run_trading_system.py
+++ b/run_trading_system.py
@@ -1,32 +1,49 @@
 from __future__ import annotations
-import asyncio, logging, signal, sys
+import asyncio
+import logging
+import signal
+import sys
 from types import FrameType
-import uvloop, config
+import uvloop
+import config
 from logger import setup_logger
 from monitoring import heartbeat, start_metrics_server
 from trading_multi import TradingBotMulti
+from risk_manager import RiskManager
 
 uvloop.install()
 setup_logger()
 logger = logging.getLogger(__name__)
 
 def _graceful(sig: int, _: FrameType | None):
+    """Cancel all tasks on termination signals."""
     logger.info("Получен сигнал %s – завершаем…", signal.Signals(sig).name)
-    for t in asyncio.all_tasks(): t.cancel()
+    for t in asyncio.all_tasks():
+        t.cancel()
 
 for s in (signal.SIGINT, signal.SIGTERM): signal.signal(s, _graceful)
 
 async def main():
+    """Run trading bot until cancelled."""
     asyncio.create_task(start_metrics_server())
     asyncio.create_task(heartbeat())
     bot = TradingBotMulti()
-    try:    await bot.run()
+    risk = RiskManager(bot)
+    asyncio.create_task(risk.watch())
+    try:
+        await bot.run()
     except asyncio.CancelledError:
         pass
-    finally: await bot.close()
+    finally:
+        await bot.close()
 
 if __name__ == "__main__":
-    logger.info("Бот стартует в режиме %s – пары: %s", config.TRADE_MODE, ", ".join(config.TRADE_PAIRS))
-    try:    asyncio.run(main())
+    logger.info(
+        "Бот стартует в режиме %s – пары: %s", config.TRADE_MODE, ", ".join(config.TRADE_PAIRS)
+    )
+    try:
+        asyncio.run(main())
     except KeyboardInterrupt:
         sys.exit(0)
+
+

--- a/slippage_sim.py
+++ b/slippage_sim.py
@@ -24,3 +24,4 @@ class SlippageSimulator:
                 break
             remain -= size
         return worst
+

--- a/trading_multi.py
+++ b/trading_multi.py
@@ -73,3 +73,4 @@ class TradingBotMulti:
         PNL_TOTAL.labels(sym=sym).set(float(self.real[sym]))
 
     async def close(self): await self.client.close()
+

--- a/ws_manager.py
+++ b/ws_manager.py
@@ -1,22 +1,80 @@
 from __future__ import annotations
-import asyncio, logging
-from typing import Awaitable, Callable, TypeVar
-import tenacity
+import asyncio
+import json
+import logging
+from decimal import Decimal
+import websockets
+import config
+from monitoring import WS_RECONNECTS
 
 logger = logging.getLogger(__name__)
-_T = TypeVar("_T")
 
-async def retry_async(
-    func: Callable[[], Awaitable[_T]],
-    *, attempts: int = 4, wait: float = 0.5, backoff: float = 2.0
-) -> _T:
-    @tenacity.retry(
-        reraise=True,
-        stop=tenacity.stop_after_attempt(attempts),
-        wait=tenacity.wait_exponential(multiplier=wait, exp_base=backoff),
-        before_sleep=lambda rs: logger.warning(
-            "retry %s/%s: %s", rs.attempt_number, attempts, rs.outcome.exception()),
-    )
-    async def _wrapper() -> _T:
-        return await func()
-    return await _wrapper()
+class WSManager:
+    """Maintain WebSocket connection and stream best bid/ask quotes."""
+
+    URL_MAIN = "wss://stream.bybit.com/v5/public/linear"
+    URL_TEST = "wss://stream-testnet.bybit.com/v5/public/linear"
+    RECONNECT_DELAY = 5
+
+    def __init__(self, client: "APIClient") -> None:  # noqa: F821
+        self.client = client
+        self.conn: websockets.WebSocketClientProtocol | None = None
+        self.best: dict[str, tuple[Decimal, Decimal]] = {
+            s: (Decimal(), Decimal()) for s in config.TRADE_PAIRS
+        }
+        self._task: asyncio.Task | None = None
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        if not self._task:
+            self._stop.clear()
+            self._task = asyncio.create_task(self._run())
+
+    async def _run(self) -> None:
+        url = self.URL_TEST if config.USE_TESTNET else self.URL_MAIN
+        subs = [f"orderbook.1.{sym}" for sym in config.TRADE_PAIRS]
+        while not self._stop.is_set():
+            try:
+                async with websockets.connect(url) as conn:
+                    self.conn = conn
+                    await conn.send(json.dumps({"op": "subscribe", "args": subs}))
+                    logger.info("WS subscribed to %s", ", ".join(subs))
+                    await self._listener(conn)
+            except Exception as exc:
+                WS_RECONNECTS.inc()
+                logger.warning(
+                    "WS reconnect in %s sec: %s", self.RECONNECT_DELAY, exc
+                )
+                await asyncio.sleep(self.RECONNECT_DELAY)
+
+    async def _listener(self, conn: websockets.WebSocketClientProtocol) -> None:
+        async for msg in conn:
+            data = json.loads(msg)
+            ob = data.get("data")
+            if not ob:
+                continue
+            sym = ob.get("s")
+            if sym and sym in self.best:
+                bid = Decimal(str(ob["b"][0][0]))
+                ask = Decimal(str(ob["a"][0][0]))
+                self.best[sym] = (bid, ask)
+
+    async def get_best(self, sym: str) -> tuple[Decimal, Decimal]:
+        while True:
+            bid, ask = self.best.get(sym, (Decimal(), Decimal()))
+            if bid and ask:
+                return bid, ask
+            await asyncio.sleep(0.1)
+
+    async def close(self) -> None:
+        self._stop.set()
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+        if self.conn:
+            await self.conn.close()
+


### PR DESCRIPTION
## Summary
- add configurable drawdown limit in config
- implement RiskManager to halt trading on heavy losses
- integrate risk monitoring in bot startup
- document drawdown threshold in README

## Testing
- `python3 -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6885382e29f0832ea2a2d8711142acb9